### PR TITLE
Handle multiple sheet variable.names out of xls(x).reader()

### DIFF
--- a/R/load.project.R
+++ b/R/load.project.R
@@ -211,6 +211,15 @@ load.project <- function(override.config = NULL)
                      filename,
                      variable.name))
 
+        ## Most times, variable.name will correspond to one loaded object
+        ## but in the case of xls(x) readers, they always return
+        ## variable.name.Sheet1 ... variable.name.SheetN
+        if (grepl('xls', extension)) {
+          variable.name <- grep(paste(variable.name, 'Sheet', sep ='.'),
+                                ls(.TargetEnv),
+                                value = TRUE)
+        }
+
         data.files.loaded <- c(data.files.loaded, variable.name)
 
         break()


### PR DESCRIPTION
Accounts for these specific readers within .load.data()

Fixes #137 
