### PR TITLE
add dplyr to default libraries in global.dcf

### DIFF
--- a/inst/defaults/full/config/global.dcf
+++ b/inst/defaults/full/config/global.dcf
@@ -5,7 +5,7 @@ recursive_loading: FALSE
 munging: TRUE
 logging: FALSE
 load_libraries: FALSE
-libraries: reshape, plyr, ggplot2, stringr, lubridate
+libraries: reshape, plyr, dplyr, ggplot2, stringr, lubridate
 as_factors: TRUE
 data_tables: FALSE
 attach_internal_libraries: FALSE


### PR DESCRIPTION
suggest adding dplyr as a default library to load