### PR TITLE
allow extra arguments to be passed from cache to save

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -8,6 +8,8 @@
 #' @param variable A character vector containing the name of the variable to
 #'  be saved.
 #'
+#' @param ... additional arguments passed to \code{\link{save}}
+#'
 #' @return No value is returned; this function is called for its side effects.
 #'
 #' @export
@@ -22,10 +24,11 @@
 #'
 #' setwd('..')
 #' unlink('tmp-project')}
-cache <- function(variable)
+cache <- function(variable, ...)
 {
+  stopifnot(length(variable) == 1)
   save(list = variable,
        envir = .TargetEnv,
-       file = file.path('cache',
-                        paste(variable, '.RData', sep = '')))
+       file = file.path('cache', paste0(variable, '.RData')),
+       ...)
 }


### PR DESCRIPTION
Suggestion as discussed in #147.

NOTE: I have only updated the R-file! I have a newer version of Roxygen2, that uses a slightly different approach to logg its version number in the generated files etc. I therfore chosed not to to update since it might introduce bigger changes than intended!

NOTE ALSO: I do not pass all the testthat tests after the change but I do not think this is related to the suggested change but to something else (that I do not have the possibility to investigate right now). Hence, I do not think that it was this change that introduced the test failure on my computer.