### PR TITLE
Allow to call RSQLite's initExtension()

### DIFF
--- a/R/sql.reader.R
+++ b/R/sql.reader.R
@@ -174,6 +174,11 @@ sql.reader <- function(data.file, filename, variable.name)
 
     connection <- DBI::dbConnect(sqlite.driver,
                             dbname = database.info[['dbname']])
+
+    if (!is.null(database.info[['plugin']]) && database.info[['plugin']] == 'extension')
+    {
+      RSQLite::initExtension(connection)
+    }
   }
 
   if (database.info[['type']] == 'postgres')

--- a/R/sql.reader.R
+++ b/R/sql.reader.R
@@ -90,6 +90,17 @@
 #' dbname: herokudb
 #' query: select * from emp
 #'
+#' Example 11
+#' In this example RSQLite::initExtension() is automatically called on the established connection.
+#'
+#' Liam Healy has written extension-functions.c, which is available on http://www.sqlite.org/contrib.
+#' It provides mathematical and string extension functions for SQL queries using the loadable extensions mechanism.
+#'
+#' type: sqlite
+#' dbname: /path/to/sample_database
+#' plugin: extension
+#' query: SELECT *,STDEV(value1) FROM example_table
+#'
 #' @param data.file The name of the data file to be read.
 #' @param filename The path to the data set to be loaded.
 #' @param variable.name The name to be assigned to in the global environment.

--- a/man/sql.reader.Rd
+++ b/man/sql.reader.Rd
@@ -107,6 +107,17 @@ host: heroku.postgres.url
 port: 1234
 dbname: herokudb
 query: select * from emp
+
+Example 11
+In this example RSQLite::initExtension() is automatically called on the established connection.
+
+Liam Healy has written extension-functions.c, which is available on http://www.sqlite.org/contrib.
+It provides mathematical and string extension functions for SQL queries using the loadable extensions mechanism.
+
+type: sqlite
+dbname: /path/to/sample_database
+plugin: extension
+query: SELECT *,STDEV(value1) FROM example_table
 }
 \examples{
 library('ProjectTemplate')


### PR DESCRIPTION
RSQLite has the function initExtension() to automatically load extension-functions.c (50.96 KB) contributed by Liam Healy on 2010-02-06 15:45:07 (https://www.sqlite.org/contrib?orderby=date)

It provides mathematical and string extension functions for SQL queries using the loadable extensions mechanism. Math: acos, asin, atan, atn2, atan2, acosh, asinh, atanh, difference, degrees, radians, cos, sin, tan, cot, cosh, sinh, tanh, coth, exp, log, log10, power, sign, sqrt, square, ceil, floor, pi. String: replicate, charindex, leftstr, rightstr, ltrim, rtrim, trim, replace, reverse, proper, padl, padr, padc, strfilter. Aggregate: stdev, variance, mode, median, lower_quartile, upper_quartile.

The pull request adds a config option in the .sql files to call initExtension()

Thanks!