### PR TITLE
Fix bug in .load.cache() and refactor

### DIFF
--- a/R/load.project.R
+++ b/R/load.project.R
@@ -155,47 +155,6 @@ load.project <- function(override.config = NULL)
   suppressWarnings(rm(list = c("config", "logger", "project.info"), envir = .TargetEnv))
 }
 
-.load.cache <- function() {
-  .provide.directory('cache')
-  cache.files <- dir('cache')
-  cached.files <- c()
-
-  for (cache.file in cache.files)
-  {
-    filename <- file.path('cache', cache.file)
-
-    for (extension in ls(extensions.dispatch.table))
-    {
-      if (grepl(extension, cache.file, ignore.case = TRUE, perl = TRUE))
-      {
-        variable.name <- clean.variable.name(sub(extension,
-                                                 '',
-                                                 cache.file,
-                                                 ignore.case = TRUE,
-                                                 perl = TRUE))
-
-        # If this variable already exists in the global environment, don't load it from cache.
-        if (variable.name %in% ls(envir = .TargetEnv))
-        {
-          next()
-        }
-
-        message(paste(" Loading cached data set: ", variable.name, sep = ''))
-
-        do.call(extensions.dispatch.table[[extension]],
-                list(cache.file,
-                     filename,
-                     variable.name))
-
-        cached.files <- c(cached.files, variable.name)
-
-        break()
-      }
-    }
-  }
-
-  cached.files
-}
 
 .load.data <- function(recursive) {
   .provide.directory('data')

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -281,3 +281,27 @@ test_that('re-caching a variable created from CODE only happens if code changes,
         
 })
 
+test_that('caching a variable with an underscore is not unnecessarily loaded next load.project()', {
+        
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project, minimal = FALSE))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+        
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+        
+        var_to_cache <- "xx_xx"
+        test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
+        assign(var_to_cache, test_data, envir = .TargetEnv)
+        
+        # Create a new cached version
+        expect_message(cache(var_to_cache, CODE = NULL, depends = NULL), 
+                       "Creating cache entry from global environment")
+        
+        # Load up from cache and check no message contains an x
+        expect_message(load.project(), "[^[^x]+$")
+        
+        
+        tidy_up()
+        
+})


### PR DESCRIPTION
This PR fixes a bug in cache loading:

If a variable containing an underscore is cached (e.g. en_docs), then on a subsequent `load.project()`, the `.load.cache()` function tests for the existence of a variable called `en.docs`, doesn't find it and then proceeds to load `en_docs` from the cache..  So the correct variable ends up in global env, but an unnecessary load has occurred if it was already there.

On inspecting the code, a few things became apparent from the way `.load.cache()` works:

 - the cache load code is essentially a cut and paste of the generic `data` load code.  It essentially supports loading any kind of cached variable extension, whereas the `cache()` function only ever writes `.RData` files (this was true even before the recent enhancements to `cache()`.  So, to be consistent, caching should only read `.RData` files and users should be discouraged from putting other types of data in that directory (that's what `data` is for after all).
 - The `clean.variable.name()` function is called before checking against memory.  This is where `en_docs` would get transposed into `en.docs`.  However, the `rdata.reader` doesn't use this cleaned variable name which is why the correct name got loaded into memory

I think that `clean.variable.name` needs to stay for raw data reads, but once a variable is in memory (maybe even created in a subsequent munge script) then it should be cached without modification.  This happens today by default (except for the edge case described above) but only because the `rdata.reader` doesn't enforce cleaned up variable names.

In fixing this, I have done the following:

- removed all the dispatch extension checking in favour of only looking for RData files
 - removed the clean.variable call
 - moved the whole function to the `cache.R` file to make it easier to maintain going forward (e.g. if the way caching is done changes going forward, the `.load.cache` and `.write.cache` functions are next to each other
 - removed the call to `rdata.reader` which only wraps a `load` call.  This is in case it is updated in the future to support `clean.variable.name` during data load.

No user documentation changes have been made as the overall behaviour hasn't changed.

 