### PR TITLE
Enable dcf files to contain R code that can be evaluated upon read

### DIFF
--- a/R/translate.dcf.R
+++ b/R/translate.dcf.R
@@ -5,7 +5,7 @@
 #' for configuration settings and ad hoc file format specifications.
 #' 
 #' The content of the DCF file are stored as character strings.  If the content
-#' is placed between the back tick character \code{`}, then the content is 
+#' is placed between the back tick character , then the content is 
 #' evaluated as R code and the result returned in a string
 #'
 #' @param filename A character vector specifying the DCF file to be
@@ -30,7 +30,7 @@ translate.dcf <- function(filename)
           value <- settings[[s]]
           r_code <- gsub("^`(.*)`$", "\\1", value)
           if (nchar(r_code) != nchar(value)) {
-                  value <- eval(parse(text=r_code))
+                  settings[[s]] <- eval(parse(text=r_code))
           }
   }
   settings

--- a/R/translate.dcf.R
+++ b/R/translate.dcf.R
@@ -3,6 +3,10 @@
 #' This function will read a DCF file and translate the resulting
 #' data frame into a list. The DCF format is used throughout ProjectTemplate
 #' for configuration settings and ad hoc file format specifications.
+#' 
+#' The content of the DCF file are stored as character strings.  If the content
+#' is placed between the back tick character \code{`}, then the content is 
+#' evaluated as R code and the result returned in a string
 #'
 #' @param filename A character vector specifying the DCF file to be
 #'   translated.
@@ -19,5 +23,16 @@
 translate.dcf <- function(filename)
 {
   settings <- read.dcf(filename)
-  setNames(as.list(as.character(settings)), colnames(settings))
+  settings <- setNames(as.list(as.character(settings)), colnames(settings))
+  
+  # Check each setting to see if it contains R code
+  for (s in names(settings)) {
+          value <- settings[[s]]
+          r_code <- gsub("^`(.*)`$", "\\1", value)
+          if (nchar(r_code) != nchar(value)) {
+                  value <- eval(parse(text=r_code))
+          }
+  }
+  settings
 }
+

--- a/man/translate.dcf.Rd
+++ b/man/translate.dcf.Rd
@@ -18,6 +18,11 @@ This function will read a DCF file and translate the resulting
 data frame into a list. The DCF format is used throughout ProjectTemplate
 for configuration settings and ad hoc file format specifications.
 }
+\details{
+The content of the DCF file are stored as character strings.  If the content
+is placed between the back tick character , then the content is 
+evaluated as R code and the result returned in a string
+}
 \examples{
 library('ProjectTemplate')
 

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -55,3 +55,25 @@ test_that('project.config() displays standard and additional config correctly', 
         
         
 })
+
+test_that('R code in between back ticks is evaluated in config files', {
+        
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project, minimal = TRUE))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+        
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+        
+        # Set an environment variable to an old version number
+        Sys.setenv(version="0.1")
+        on.exit(Sys.unsetenv("version"))
+        
+        config <- .load.config()
+        #change the version number field to be some R code to retrieve the environment variable
+        config$version <- '`Sys.getenv("version")`'
+        write.dcf(config, .project.config)
+        
+        expect_warning(load.project(), "compatible with version 0.1")
+        
+})


### PR DESCRIPTION
This PR proposes a change referenced in #30 and recently commented upon by @kezkankrayon.

A generic change is made to the `translate.dcf` function which is used in a number of places to read DCF files.  In particular, this is used by the SQL reader where it was requested to support user names and passwords in environment variables.

The change is that any item in a DCF file contained in back ticks is evaluated as R code and the result used in place for that variable.  This is a similar pattern to that used in R Markdown documents for evaluating code.

As an example, if a DCF file looks like this:

```
    user:  `Sys.getenv("user")`
   passwd:  `Sys.getenv("sql_password")`
```
then the `user` and `passwd` variables are set with the results of the environment variables.

A test case was also written to test the functionality, and the man page documentation is updated.

