### PR TITLE
run cache() CODE chunks in a local environment

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -289,7 +289,7 @@ cache <- function(variable=NULL, CODE=NULL, depends=NULL,  ...)
 
 .evaluate.code <- function (variable, CODE) {
         # run code and assignthe results to variable in the global env
-        result <- eval(parse(text=CODE), envir = .TargetEnv)
+        result <- eval(parse(text=CODE), envir = new.env())
         assign(variable, result, envir = .TargetEnv)
 }
 

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -305,3 +305,39 @@ test_that('caching a variable with an underscore is not unnecessarily loaded nex
         tidy_up()
         
 })
+
+test_that('caching a variable using CODE doesnt leave variables in globalenv', {
+        
+        test_project <- tempfile('test_project')
+        suppressMessages(create.project(test_project, minimal = FALSE))
+        on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
+        
+        oldwd <- setwd(test_project)
+        on.exit(setwd(oldwd), add = TRUE)
+        
+        var_to_cache <- "xxxx"
+        
+        # make sure it doesn't exist
+        if (exists(var_to_cache, envir = .TargetEnv )) {
+                rm(list=var_to_cache, envir = .TargetEnv)
+        }
+        
+        # set an environment variable in global env
+        assign("yyy", 10, envir = .TargetEnv)
+        
+        # create a cached variable 
+        cache(var_to_cache, CODE = {
+                aaa <- 10
+                bbb <- 10
+                aaa*bbb*yyy
+        })
+        
+        # check variable calculates correctly
+        expect_equal(get(var_to_cache), 10*10*10)
+        
+        # Make sure local variables don't exist in global env
+        expect_true(!exists("aaa"))
+        expect_true(!exists("bbb"))
+                       
+        tidy_up()
+})


### PR DESCRIPTION
This PR proposes a modification to the way `cache()` handles `CODE` chunk execution.

Currently, the chunk is run in global environment and the result of the execution is assigned to the variable name specified in the `cache(variable_name, ...)` call.  This has the side effect that if some helper variables are used in the `CODE` chunk, these are also placed in the global environment.  This is a bit messy as the `CODE` chunk should really only produce the single intended variable in global environment.

This fix runs the `CODE` chunk in a local environment and saves the result in the appropriate global environment variable.  Some additional tests are included to check the behaviour.
