### PR TITLE
Remove dot variables in global env when clear() is run

### DIFF
--- a/R/clear.R
+++ b/R/clear.R
@@ -6,7 +6,7 @@
 #'
 #' @param ... A sequence of character strings  of the objects to
 #'  be removed from the global environment.  If none given, then all items except
-#'  those in \code{keep} will be deleted.
+#'  those in \code{keep} will be deleted.  This includes items beginning with \code{.}
 #' @param keep A character vector of variables that should remain in the global
 #'  environment
 #' @param force If \code{TRUE}, then variables will be deleted even if 
@@ -33,7 +33,7 @@ clear <- function (..., keep=c(), force=FALSE) {
         
         # If no ... specified, get everything from global environment
         if (length(names) == 0L) 
-                names <- ls(envir = .TargetEnv)
+                names <- ls(envir = .TargetEnv, all.names = TRUE)
         else {
                 # Remove any names not in the Global Env
                 not_in_genv <- !sapply(names, exists)

--- a/man/clear.Rd
+++ b/man/clear.Rd
@@ -9,7 +9,7 @@ clear(..., keep = c(), force = FALSE)
 \arguments{
 \item{...}{A sequence of character strings  of the objects to
 be removed from the global environment.  If none given, then all items except
-those in \code{keep} will be deleted.}
+those in \code{keep} will be deleted.  This includes items beginning with \code{.}}
 
 \item{keep}{A character vector of variables that should remain in the global
 environment}


### PR DESCRIPTION
This PR enables all variables to be removed from the global environment by `clear()` including those beginning with a dot (except if they are protected by `config$sticky_vars`).

This assists with some hard-to-track bugs where there is a `.variable` in global env that conflicts with something in a package, and the package value is masked by precedence.  You can't necessarily see these variables by default using `ls()`.  Also, if you use RStudio, it saves a snapshot of global env across restarts perpetuating the problem.

I'm pretty sure this happened to me when working on #163.  Tests passed on my local machine but not travis - I was missing a function `.var.diff.from` in the package which was being masked because it was lurking in the global environment.

I added a small documentation update on the man page and also some regression tests.