### PR TITLE
Renamed doc to docs and added references to GitHub Pages configuration

### DIFF
--- a/R/create.project.R
+++ b/R/create.project.R
@@ -44,14 +44,14 @@ create.project <- function(project.name = 'new-project', minimal = FALSE,
 
   .stopifproject(c("Cannot create a new project inside an existing one",
                            "Please change to another directory and re-run create.project()"))
-  
+
   .stopifproject(c("Cannot create a new project inside an existing one",
                    "Please change to another directory and re-run create.project()"),
-                   path=dirname(getwd()))
-  
-  
+                 path = dirname(getwd()))
+
+
   if (minimal) {
-    exclude <- c("diagnostics", "doc", "graphs", "lib", "logs", "profiling",
+    exclude <- c("diagnostics", "docs", "graphs", "lib", "logs", "profiling",
                  "reports", "tests", "TODO")
   } else {
     exclude <- c()
@@ -92,17 +92,17 @@ create.project <- function(project.name = 'new-project', minimal = FALSE,
 
   switch(
     merge.strategy,
-    require.empty={
+    require.empty = {
       if (!.dir.empty(project.path))
         stop(paste("Directory", project.path,
                    "not empty.  Use merge.strategy = 'allow.non.conflict' to override."))
     },
-    allow.non.conflict={
+    allow.non.conflict = {
       target.file.exists <- file.exists(file.path(project.path, template.files))
       if (any(target.file.exists))
         stop(paste("Creating a project in ", project.path,
                    " would overwrite the following existing files/directories:\n",
-                   paste(template.files[target.file.exists], collapse=', ')))
+                   paste(template.files[target.file.exists], collapse = ', ')))
     },
     stop("Invalid value for merge.strategy:", merge.strategy))
 

--- a/R/migrate.project.R
+++ b/R/migrate.project.R
@@ -26,7 +26,8 @@ migrate.project <- function()
 
   # Initialise migration flags
   config_conflicts <- FALSE
-  directory_conflicts <- FALSE
+  version_conflict <- FALSE
+  other_conflicts <- FALSE
   config_warnings <- NULL
 
   # Flags stored in environment env
@@ -45,15 +46,14 @@ migrate.project <- function()
       suppressWarnings(.load.config())
     }
   )
+  version_conflict <- .check.version(loaded.config, warn.migrate = FALSE) != 0
 
   # Detect other migration issues
   doc_not_renamed <- dir.exists("doc") && !dir.exists("docs")
-  directory_conflicts <- any(doc_not_renamed)
+  other_conflicts <- any(doc_not_renamed)
 
   # Exit if everything up to date
-  if ((.check.version(loaded.config, warn.migrate = FALSE) == 0) &&
-      !config_conflicts && !directory_conflicts
-    ) {
+  if (!any(version_conflict, config_conflicts, other_conflicts)) {
     message("Already up to date.")
     return(invisible(NULL))
   }
@@ -63,39 +63,35 @@ migrate.project <- function()
   # Process config conflicts
   if (config_conflicts) {
     # Tell the user about problems with their old config
-    message(paste0(c(
+    message(paste(
       "Your existing project configuration in globals.dcf does not contain up to",
       paste0("date configuration settings in this version ",
              .package.version(),
              " of ProjectTemplate.  They will"),
-      "be added automatically during migration, but you should review afterward."
-    ),
-    collapse = "\n"))
+      "be added automatically during migration, but you should review afterward.",
+      sep = "\n"))
 
     if (grepl("missing a configuration file", config_warnings)) {
-      message(paste0(c(
+      message(paste(
         "You didn't have a config.dcf file.  One has been created",
-        "for you using default values"
-      ),
-      collapse = "\n"))
+        "for you using default values",
+        sep = "\n"))
     }
 
     if (grepl("missing the following entries", config_warnings)) {
-      message(paste0(c(
+      message(paste(
         "Your config.dcf file was missing entries and defaults",
-        "have been used.  The missing entries are:"
-      ),
-      collapse = "\n"))
+        "have been used.  The missing entries are:",
+        sep = "\n"))
       missing <- sub(".*missing the following entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
       message(missing)
     }
 
     if (grepl("contains the following unused entries", config_warnings)) {
-      message(paste0(c(
+      message(paste(
         "Your config.dcf file contained unused entries which have been",
-        "removed.  The unused entries are:"
-      ),
-      collapse = "\n"))
+        "removed.  The unused entries are:",
+        sep = "\n"))
       unused <- sub(".*contains the following unused entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
       message(unused)
     }
@@ -105,28 +101,24 @@ migrate.project <- function()
       # switch the setting to FALSE so as to not mess up any existing
       # munge script, but warn the user
       loaded.config$cache_loaded_data <- FALSE
-      message(paste0(c(
-        "\n",
+      message(paste("",
         "There is a new config item called cache_loaded_data which auto-caches data",
         "after it has been loaded from the data directory.  This has been switched",
         "off for this project in case it breaks your scripts.  However you can switch",
-        "it on manually by editing global.dcf"),
-        collapse = "\n"))
+        "it on manually by editing global.dcf",
+        sep = "\n"))
     }
   }
 
   # Process other migration conflicts
   if (doc_not_renamed) {
-    message(paste(
+    message(paste("",
+      "The doc directory has now been deprecated and ProjectTemplate now uses docs",
+      "instead. This is to ease integration with GitHub Pages (See",
+      "https://github.com/blog/2289-publishing-with-github-pages-now-as-easy-as-1-2-3).",
       "",
-      "The doc directory has been renamed to docs for new projects. This was",
-      "done to make it easy use the new option for GitHub Pages to use the docs",
-      "directory as the root for your website.",
-      "The new docs directory has been created in this project, but no files have",
-      "been moved to prevent links from breaking. Please move the files manually",
-      "and remove the old directory to be fully up to date with ProjectTemplate!",
-      "See https://github.com/blog/2289-publishing-with-github-pages-now-as-easy-as-1-2-3",
-      "for more information on how to configure GitHub Pages.",
+      "A new docs directory has been created in this project, but your existing doc",
+      "directory remains.  Please review and move manually if you wish.",
       sep = "\n"
     ))
     file.copy(system.file(file.path('defaults', 'full', 'docs'),
@@ -138,6 +130,4 @@ migrate.project <- function()
 
   # Finally, save the validated configuration with the updated version number
   .save.config(loaded.config)
-
 }
-

--- a/R/migrate.project.R
+++ b/R/migrate.project.R
@@ -17,118 +17,127 @@
 #' \dontrun{migrate.project()}
 migrate.project <- function()
 {
-  my.project.info <- list()
-
   message('Migrating project configuration')
 
   # Load the config and look for specific problems in the configuration that
   # should be fixed (e.g. missing files, missing config item)
   # Also flag up if any items need special handling during migration (for example
   # if something other than the default is appropriate for existing projects)
-  
+
   # Initialise migration flags
   config_conflicts <- FALSE
+  directory_conflicts <- FALSE
   config_warnings <- NULL
-  
-  
+
   # Flags stored in environment env
   env <- environment()
-  
+
   # Detect any conflicts with the existing config file once it has been processed
   # during load.project() (flag for now and handle later on)
-  
-  loaded.config <- tryCatch(.load.config(),
-                      warning=function(w) {
-                          # set up some variables to help process the 
-                          # migration warnings later
-                          
-                          assign("config_conflicts", TRUE, envir = env)
-                          assign("config_warnings", w$message, envir = env)
-                          suppressWarnings(.load.config())
-                      })
-          
-  # Detect other migration issues 
-  
-  
+  loaded.config <- tryCatch(
+    .load.config(),
+    warning = function(w) {
+      # set up some variables to help process the
+      # migration warnings later
+
+      assign("config_conflicts", TRUE, envir = env)
+      assign("config_warnings", w$message, envir = env)
+      suppressWarnings(.load.config())
+    }
+  )
+
+  # Detect other migration issues
+  doc_not_renamed <- dir.exists("doc") && !dir.exists("docs")
+  directory_conflicts <- any(doc_not_renamed)
 
   # Exit if everything up to date
-  if ((
-          .check.version(loaded.config, warn.migrate = FALSE) == 0) 
-       && !config_conflicts
-      ) {
-          message("Already up to date.")
-          return(invisible(NULL))
+  if ((.check.version(loaded.config, warn.migrate = FALSE) == 0) &&
+      !config_conflicts && !directory_conflicts
+    ) {
+    message("Already up to date.")
+    return(invisible(NULL))
   }
-  
+
   # Otherwise ....
-  
+
   # Process config conflicts
   if (config_conflicts) {
-          
-          # Tell the user about problems with their old config
-          
-          message(paste0(c(
-                  "Your existing project configuration in globals.dcf does not contain up to",
-                  paste0("date configuration settings in this version ",
-                  .package.version(),
-                  " of ProjectTemplate.  They will"),
-                  "be added automatically during migration, but you should review afterward."
-                  ),
-                  collapse="\n"))
-          
-          if(grepl("missing a configuration file", config_warnings)) {
-                  message(paste0(c(
-                          "You didn't have a config.dcf file.  One has been created",
-                          "for you using default values"
-                          ),
-                  collapse="\n"))
-          }
-          
-         
-          if(grepl("missing the following entries", config_warnings)) {
-                  message(paste0(c(
-                          "Your config.dcf file was missing entries and defaults",
-                          "have been used.  The missing entries are:"
-                          ),
-                  collapse="\n"))
-                  missing <- sub(".*missing the following entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
-                  message(missing)
-          }
-          
-          if(grepl("contains the following unused entries", config_warnings)) {
-                  message(paste0(c(
-                          "Your config.dcf file contained unused entries which have been",
-                          "removed.  The unused entries are:"
-                          ),
-                  collapse="\n"))
-                  unused <- sub(".*contains the following unused entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
-                  message(unused)
-          }
-          
-                    
-          # Specific logic here for new config items that need special migration treatment
-          
-          if(grepl("cache_loaded_data", config_warnings)) {
-                  # switch the setting to FALSE so as to not mess up any existing
-                  # munge script, but warn the user
-                  loaded.config$cache_loaded_data <- FALSE
-                  message(paste0(c(
-                          "\n",
-                          "There is a new config item called cache_loaded_data which auto-caches data",
-                          "after it has been loaded from the data directory.  This has been switched",
-                          "off for this project in case it breaks your scripts.  However you can switch",
-                          "it on manually by editing global.dcf"),
-                          collapse="\n"))
-          }
-          
+    # Tell the user about problems with their old config
+    message(paste0(c(
+      "Your existing project configuration in globals.dcf does not contain up to",
+      paste0("date configuration settings in this version ",
+             .package.version(),
+             " of ProjectTemplate.  They will"),
+      "be added automatically during migration, but you should review afterward."
+    ),
+    collapse = "\n"))
+
+    if (grepl("missing a configuration file", config_warnings)) {
+      message(paste0(c(
+        "You didn't have a config.dcf file.  One has been created",
+        "for you using default values"
+      ),
+      collapse = "\n"))
+    }
+
+    if (grepl("missing the following entries", config_warnings)) {
+      message(paste0(c(
+        "Your config.dcf file was missing entries and defaults",
+        "have been used.  The missing entries are:"
+      ),
+      collapse = "\n"))
+      missing <- sub(".*missing the following entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
+      message(missing)
+    }
+
+    if (grepl("contains the following unused entries", config_warnings)) {
+      message(paste0(c(
+        "Your config.dcf file contained unused entries which have been",
+        "removed.  The unused entries are:"
+      ),
+      collapse = "\n"))
+      unused <- sub(".*contains the following unused entries:([^.]*)\\.(.*)$", "\\1", config_warnings)
+      message(unused)
+    }
+
+    # Specific logic here for new config items that need special migration treatment
+    if (grepl("cache_loaded_data", config_warnings)) {
+      # switch the setting to FALSE so as to not mess up any existing
+      # munge script, but warn the user
+      loaded.config$cache_loaded_data <- FALSE
+      message(paste0(c(
+        "\n",
+        "There is a new config item called cache_loaded_data which auto-caches data",
+        "after it has been loaded from the data directory.  This has been switched",
+        "off for this project in case it breaks your scripts.  However you can switch",
+        "it on manually by editing global.dcf"),
+        collapse = "\n"))
+    }
   }
-  
+
   # Process other migration conflicts
-  
-  
-  
+  if (doc_not_renamed) {
+    message(paste(
+      "",
+      "The doc directory has been renamed to docs for new projects. This was",
+      "done to make it easy use the new option for GitHub Pages to use the docs",
+      "directory as the root for your website.",
+      "The new docs directory has been created in this project, but no files have",
+      "been moved to prevent links from breaking. Please move the files manually",
+      "and remove the old directory to be fully up to date with ProjectTemplate!",
+      "See https://github.com/blog/2289-publishing-with-github-pages-now-as-easy-as-1-2-3",
+      "for more information on how to configure GitHub Pages.",
+      sep = "\n"
+    ))
+    file.copy(system.file(file.path('defaults', 'full', 'docs'),
+                          package = 'ProjectTemplate', mustWork = TRUE),
+              '.',
+              recursive = TRUE,
+              overwrite = FALSE)
+  }
+
   # Finally, save the validated configuration with the updated version number
-  .save.config(loaded.config)   
-  
+  .save.config(loaded.config)
+
 }
 

--- a/inst/defaults/full/doc/README.md
+++ b/inst/defaults/full/doc/README.md
@@ -1,1 +1,0 @@
-Here you can store any documentation that you've written about your analysis.

--- a/inst/defaults/full/docs/README.md
+++ b/inst/defaults/full/docs/README.md
@@ -1,0 +1,4 @@
+Here you can store any documentation that you've written about your analysis.
+When pushing the project to GitHub you can use this directory as the root for a
+GitHub Pages website for the project. For more information see
+https://github.com/blog/2289-publishing-with-github-pages-now-as-easy-as-1-2-3

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -22,7 +22,7 @@ expect_full <- function() {
   expect_dir('data')
   expect_dir('diagnostics')
   expect_file(file.path('diagnostics', '1.R'))
-  expect_dir('doc')
+  expect_dir('docs')
   expect_dir('graphs')
   expect_dir('lib')
   expect_file(file.path('lib', 'helpers.R'))
@@ -51,7 +51,7 @@ expect_minimal <- function() {
   expect_file(file.path('src', 'eda.R'))
 
   expect_no_file('diagnostics')
-  expect_no_file('doc')
+  expect_no_file('docs')
   expect_no_file('graphs')
   expect_no_file('lib')
   expect_no_file('logs')
@@ -227,13 +227,13 @@ test_that('Dont create projects inside other projects', {
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
- 
-        # shouldn't be able to create a new project inside this one       
+
+        # shouldn't be able to create a new project inside this one
         expect_error(create.project("new_project"))
-        
+
         # Also shouldn't be able to create one inside a sub directory of an existing project
         setwd(file.path(test_project, 'lib'))
         expect_error(create.project("new_project"))

--- a/website/architecture.markdown
+++ b/website/architecture.markdown
@@ -13,7 +13,7 @@ As far as ProjectTemplate is concerned, a good statistical analysis project shou
     * data/
     * diagnostics/
         * 1.R
-    * doc/
+    * docs/
     * graphs/
     * lib/
         * helpers.R
@@ -32,10 +32,10 @@ As far as ProjectTemplate is concerned, a good statistical analysis project shou
 Each of these directories and files serves a specific purpose, which we describe below:
 
 * `cache`: Here you'll store any data sets that (a) are generated during a preprocessing step and (b) don't need to be regenerated every single time you analyze your data. You can use the `cache()` function to store data to this directory automatically. Any data set found in both the `cache` and `data` directories will be drawn from `cache` instead of `data` based on ProjectTemplate's priority rules.
-* `config`: Here you'll store any `ProjectTemplate` configurations settings for your project. Use the DCF format that the `read.dcf()` function parses.  If you have specific configuration unique to the project, this should be placed in `lib/globals.R`. 
+* `config`: Here you'll store any `ProjectTemplate` configurations settings for your project. Use the DCF format that the `read.dcf()` function parses.  If you have specific configuration unique to the project, this should be placed in `lib/globals.R`.
 * `data`: Here you'll store your raw data files. If they are encoded in a supported file format, they'll automatically be loaded when you call `load.project()`.
 * `diagnostics`: Here you can store any scripts you use to diagnose your data sets for corruption or problematic data points.
-* `doc`: Here you can store any documentation that you've written about your analysis.
+* `docs`: Here you can store any documentation that you've written about your analysis. It can also be used as root directory for GitHub Pages to create a project website.
 * `graphs`: Here you can store any graphs that you produce.
 * `lib`: Here you'll store any files that provide useful functionality for your work, but do not constitute a statistical analysis per se. Specifically, you should use the `lib/helpers.R` script to organize any functions you use in your project that aren't quite general enough to belong in a package.  If you have project specific configuration that you'd like to store in the config object, you can specify that in `lib/globals.R`.  This is the first file loaded from `lib`, so any functions in `lib`, `munge` or `src` can reference this configuration by simply using the `config$my_config_var` form.
 * `logs`: Here you can store a log file of any work you've done on this project. If you'll be logging your work, we recommend using the [log4r](https://github.com/johnmyleswhite/log4r) package, which ProjectTemplate will automatically load for you if you turn the `logging` configuration setting on. The loglevel can be set through the `logging_level` setting in the configuration, defaults to "INFO".


### PR DESCRIPTION
Implementation of issue #177, changed the skeleton, and added relevant references to GitHub Pages (the rationale behind the change). A message is issued when `migrate.project` is called in a project where the `doc` directory exists and `docs` does not, after which the new `docs` directory is copied from the skeleton. 