### PR TITLE
Prune unused code

### DIFF
--- a/R/create.project.R
+++ b/R/create.project.R
@@ -133,9 +133,6 @@ create.project <- function(project.name = 'new-project', minimal = FALSE,
   )
 }
 
-.get.template.tar.path <- function(template.name)
-  system.file(file.path('defaults', paste0(template.name, ".tar")), package = 'ProjectTemplate')
-
 .list.files.and.dirs <- function(path) {
   # no.. not available in R 2.15.3
   files <- list.files(path = path, all.files = TRUE, include.dirs = TRUE)

--- a/R/load.project.R
+++ b/R/load.project.R
@@ -147,8 +147,6 @@ load.project <- function(override.config = NULL)
   }
 
   assign('project.info', my.project.info, envir = .TargetEnv)
-  #assign('project.info', my.project.info, envir = parent.frame())
-  #assign('project.info', my.project.info, envir = environment(create.project))
 }
 
 .unload.project <- function() {


### PR DESCRIPTION
This PR proposes a small cleanup to two functions:

- Remove unused function `.get.template.tar.path()` in `create.project`.  This doesn't get called from anywhere and doesn't appear to be relevant for how templates are created.  Perhaps it is a relic of how skeleton projects used to be created?  
 - Remove two commented out code chunks in `load.project`.  Again, looks like a design decision taken in the past and not relevant now.

No user functionality changed as a result of this PR.