### PR TITLE
Uniform reading/writing global.dcf in tests

### DIFF
--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -16,10 +16,10 @@ test_that('user commands fail when not in ProjectTemplate directory', {
         test_project <- tempfile('test_project')
         dir.create(test_project)
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
+
         # Check load.project()
         expect_error(load.project())
 
@@ -28,40 +28,40 @@ test_that('user commands fail when not in ProjectTemplate directory', {
 
         # Check cache()
         expect_error(cache())
-        
+
         # Check reload.project()
         expect_error(reload.project())
-        
+
         # Check reload.project()
         expect_error(test.project())
-        
+
         # Check stub.tests()
         expect_error(stub.tests())
-        
+
         # Check project.config()
         expect_error(project.config())
-        
+
 })
 
 test_that('auto loaded data is cached by default', {
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
-        
+
+
         test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
-        
+
         # save test data as a csv in the data directory
         write.csv(test_data, file="data/test.csv", row.names = FALSE)
-        
+
         suppressMessages(load.project())
-        
+
         # check that the cached file loads without error
         expect_error(load("cache/test.RData", envir = environment()), NA)
-        
+
         # and check that the loaded data from the cache is what we saved
         expect_equal(test, test_data)
 })
@@ -70,26 +70,26 @@ test_that('auto loaded data is not cached when cached_loaded_data is FALSE', {
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
-        
+
+
         test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
-        
+
         # save test data as a csv in the data directory
         write.csv(test_data, file="data/test.csv", row.names = FALSE)
-        
+
         # Read the config data and set cache_loaded_data to FALSE
-        config <- read.dcf("config/global.dcf")
+        config <- .read.config()
         expect_error(config$cache_loaded_data <- FALSE, NA)
-        write.dcf(config, "config/global.dcf" )
-        
+        .save.config(config)
+
         suppressMessages(load.project())
-        
+
         # check that the the test variable has not been cached
         expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
-        
+
 
 })
 
@@ -99,36 +99,36 @@ test_that('auto loaded data from an R script is cached correctly', {
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
+
         # clear the global environment
         rm(list=ls(envir = .TargetEnv), envir = .TargetEnv)
-        
+
         # create some variables in the global env that shouldn't be cached
         test_data11 <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
         test_data21 <- data.frame(Names=c("a1", "b1", "c1"), Ages=c(20,30,40))
-        
-        # Create some R code and put in data directory 
+
+        # Create some R code and put in data directory
         CODE <- paste0(deparse(substitute({
                 test_data12 <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
-                test_data22 <- data.frame(Names=c("a1", "b1", "c1"), Ages=c(20,30,40))        
-                
+                test_data22 <- data.frame(Names=c("a1", "b1", "c1"), Ages=c(20,30,40))
+
         })), collapse ="\n")
-        
+
         # save R code in the data directory
         writeLines(CODE, "data/test.R")
-        
+
         # load the project and R code
         suppressMessages(load.project())
-        
+
         # check that the test variables have been cached correctly
         expect_error(load("cache/test_data12.RData", envir = environment()), NA)
         expect_error(load("cache/test_data22.RData", envir = environment()), NA)
-        
-        # check that the other test variables have not been cached 
-        expect_error(load("cache/test_data11.RData", envir = environment()), 
+
+        # check that the other test variables have not been cached
+        expect_error(load("cache/test_data11.RData", envir = environment()),
                      "cannot open the connection")
         expect_error(load("cache/test_data21.RData", envir = environment()),
                      "cannot open the connection")

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -33,14 +33,14 @@ lapply(
 )
 
 test_that('migrating a project which doesnt need config update results in an Up to date message', {
-        
+
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
+
         # should be nothing
         expect_message(migrate.project(), "Already up to date")
         tidy_up()
@@ -49,132 +49,132 @@ test_that('migrating a project which doesnt need config update results in an Up 
 
 
 test_that('projects without the cached_loaded_data config have their migrated config set to FALSE ', {
-        
+
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
 
         # Read the config data and remove the cache_loaded_data flag
-        config <- as.data.frame(read.dcf("config/global.dcf"))
+        config <- .read.config()
         expect_error(config$cache_loaded_data <- NULL, NA)
-        write.dcf(config, "config/global.dcf" )
-        
+        .save.config(config)
+
         # should get a warning because of the missing cache_loaded_data
         expect_warning(suppressMessages(load.project()), "missing the following entries")
-        
+
         test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
-        
+
         # save test data as a csv in the data directory
         write.csv(test_data, file="data/test.csv", row.names = FALSE)
-        
-        
+
+
         # run load.project again and check that the the test variable has not been cached
         # because the default should be FALSE if the missing_loaded_data is missing before migrate.project
         # is called
         suppressMessages(load.project())
         expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
-        
+
         # Migrate the project
         expect_message(migrate.project(), "new config item called cache_loaded_data")
-        
+
         # Read the config data and check cached_loaded_data is FALSE
-        config <- as.data.frame(read.dcf("config/global.dcf"), stringsAsFactors=FALSE)
-        expect_equal(config$cache_loaded_data, "FALSE")
-        
+        config <- .read.config()
+        expect_equal(config$cache_loaded_data, FALSE)
+
         # Should be a clean load.project
         expect_warning(suppressMessages(load.project()), NA)
-        
+
         # check that the the test variable has not been cached
         expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
-        
-        
+
+
 })
 
 
 test_that('migrating a project with a missing config file results in a message to user', {
-        
+
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
 
         # remove the config file
         unlink('config/global.dcf')
-        
+
         # should be a message to say no config file
         expect_message(migrate.project(), "didn't have a config\\.dcf file")
-        
-        
+
+
         suppressMessages(load.project())
-        
+
         # Get the default config
         default_config <- .read.config(.default.config.file)
         default_config$version <- .package.version()
-        
+
         # check the config is all the default
         expect_equal(get.project()$config, default_config)
-        
+
         tidy_up()
 })
 
 
 
 test_that('migrating a project with a missing config item results in a message to user', {
-        
+
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
+
         suppressMessages(load.project())
-        
+
         # remove the config item
         config$data_loading <- NULL
         .save.config(config)
-        
+
         # should be a message to say no config item
         expect_message(migrate.project(), "data_loading")
-        
+
         suppressMessages(load.project())
-        
+
         # check the missing config item is the default value
         default_config <- .read.config(.default.config.file)
         expect_equal(get.project()$config$data_loading, default_config$data_loading)
-        
+
         tidy_up()
 })
 
 
 test_that('migrating a project with a dummy config item results in a message to user', {
-        
+
         test_project <- tempfile('test_project')
         suppressMessages(create.project(test_project, minimal = FALSE))
         on.exit(unlink(test_project, recursive = TRUE), add = TRUE)
-        
+
         oldwd <- setwd(test_project)
         on.exit(setwd(oldwd), add = TRUE)
-        
+
         suppressMessages(load.project())
-        
+
         # add the dummy config item
         config$dummy <- TRUE
         .save.config(config)
-        
+
         # should be a message to say no config item
         expect_message(migrate.project(), "dummy")
-        
+
         suppressMessages(load.project())
-        
+
         # check that the dummy config item is not in the config
         expect_null(get.project()$config$dummy)
-        
+
         tidy_up()
 })
 


### PR DESCRIPTION
Several tests were failing locally because `read.dcf` was used to read `config/global.dcf` without `all = TRUE`, but then accessed as a data.frame. This PR removes all variants of `read.dcf`, `read.dcf(all=TRUE)` and `as.data.frame(read.dcf(...))` with the internal `.read.config`. Similarly `.write.dcf` has been replaced with `.write.config` where applicable. Using `read.dcf` directly returns a matrix by default, by accessing it as a list the matrix was converted to a list, however, losing the names. The dcf that was written therefore contained only variables like `X.1`, `X.2`, ...
Furthermore a lot of whitespace was cleaned up according to the Rstudio project settings.