### PR TITLE
Remove warnings from Travis and devtools::test() checks

### DIFF
--- a/R/clear.R
+++ b/R/clear.R
@@ -60,8 +60,10 @@ clear <- function (..., keep=c(), force=FALSE) {
 
         # If we're in a project template directory, load a copy of config to
         # make sure it's the latest into the global env  
-        if (.is.ProjectTemplate()) 
-                assign("config", .load.config(), envir = .TargetEnv)
+        if (.is.ProjectTemplate()) {
+                config <- .load.config()
+                assign("config", config, envir = .TargetEnv)
+        }
         
         # If config$sticky_variables exists, add it to keep and also add
         # config itself so that is preserved after the clear

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -92,7 +92,7 @@ test_that('auto loaded data is not cached when cached_loaded_data is FALSE', {
         suppressMessages(load.project())
 
         # check that the the test variable has not been cached
-        expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
+        expect_error(suppressWarnings(load("cache/test.RData", envir = environment())), "cannot open the connection")
 
 
 })
@@ -132,9 +132,9 @@ test_that('auto loaded data from an R script is cached correctly', {
         expect_error(load("cache/test_data22.RData", envir = environment()), NA)
 
         # check that the other test variables have not been cached
-        expect_error(load("cache/test_data11.RData", envir = environment()),
+        expect_error(suppressWarnings(load("cache/test_data11.RData", envir = environment())),
                      "cannot open the connection")
-        expect_error(load("cache/test_data21.RData", envir = environment()),
+        expect_error(suppressWarnings(load("cache/test_data21.RData", envir = environment())),
                      "cannot open the connection")
 })
 
@@ -151,7 +151,7 @@ test_that('ignored data files are not loaded', {
   rm(list = ls(envir = .TargetEnv), envir = .TargetEnv)
 
   # Read the config data and set cache_loaded_data to FALSE
-  config <- read.dcf("config/global.dcf")
+  config <- translate.dcf("config/global.dcf")
   expect_error(config$cache_loaded_data <- FALSE, NA)
   write.dcf(config, "config/global.dcf" )
 

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -178,7 +178,7 @@ test_that('ignored data files are not loaded', {
   # reload the project, now with an illegal Thumbs.db
   rm(list = ls(envir = .TargetEnv), envir = .TargetEnv)
   # The Thumbs.db is not a valid SQLite database so should raise an error
-  expect_error(suppressMessages(load.project(override.config = list(data_ignore = ''))))
+  expect_error(load.project(override.config = list(data_ignore = '')), "file is encrypted or is not a database")
 
   # reload the project, ignore *.csv
   rm(list = ls(envir = .TargetEnv), envir = .TargetEnv)

--- a/tests/testthat/test-migration.R
+++ b/tests/testthat/test-migration.R
@@ -72,10 +72,10 @@ test_that('projects without the cached_loaded_data config have their migrated co
 
 
         # run load.project again and check that the the test variable has not been cached
-        # because the default should be FALSE if the missing_loaded_data is missing before migrate.project
+        # because the default should be FALSE if the cache_loaded_data is missing before migrate.project
         # is called
-        suppressMessages(load.project())
-        expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
+        expect_warning(suppressMessages(load.project()), "missing the following entries: cache_loaded_data")
+        expect_error(suppressWarnings(load("cache/test.RData", envir = environment())), "cannot open the connection")
 
         # Migrate the project
         expect_message(migrate.project(), "new config item called cache_loaded_data")
@@ -88,7 +88,7 @@ test_that('projects without the cached_loaded_data config have their migrated co
         expect_warning(suppressMessages(load.project()), NA)
 
         # check that the the test variable has not been cached
-        expect_error(load("cache/test.RData", envir = environment()), "cannot open the connection")
+        expect_error(suppressWarnings(load("cache/test.RData", envir = environment())), "cannot open the connection")
 
 
 })


### PR DESCRIPTION
This PR proposes some updates to the existing code base to prevent warnings thrown by some test tools.  This was discussed in #186.

The warnings fixed by this are:

- those thrown when `devtools::test()` is run in the `ProjectTemplate` directory
- when examining the travis console screen warnings were shown about the binding of the `config` variable in `.remove.sticky.variables()` function.

No user functionality is changed in this PR, it simply cleans up some underlying test cases to improve the regression suite.