### PR TITLE
Feature request #215: Convert data.frame to tibble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ Suggests:
     RPostgreSQL,
     GetoptLong,
     whisker,
+    tibble,
     testthat (>= 0.8)
 URL: http://projecttemplate.net
 BugReports: https://github.com/johnmyleswhite/ProjectTemplate/issues

--- a/R/load.project.R
+++ b/R/load.project.R
@@ -175,6 +175,8 @@ load.project <- function(override.config = NULL)
 
       if (config$data_tables) {
         .convert.to.data.table(vars.new)
+      } else {
+        .convert.to.tibble(vars.new)
       }
 
       if (config$cache_loaded_data && length(vars.new) > 0) {
@@ -200,6 +202,20 @@ load.project <- function(override.config = NULL)
     if (all(class(loaded.data) == 'data.frame')) {
       message(' Translating data.frame to data.table: ', data.set)
       assign(data.set, data.table::data.table(loaded.data), envir = .TargetEnv)
+    }
+  }
+}
+
+## Convert datasets to tibble
+.convert.to.tibble <- function(data.sets) {
+  require.package("tibble", FALSE)
+
+  for (data.set in data.sets) {
+    # Get current version of the dataset
+    loaded.data <- get(data.set, envir = .TargetEnv, inherits = FALSE)
+    if (all(class(loaded.data) == 'data.frame')) {
+      message(' Translating data.frame to tibble: ', data.set)
+      assign(data.set, tibble::as_tibble(loaded.data), envir = .TargetEnv)
     }
   }
 }

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -54,7 +54,7 @@ test_that('auto loaded data is cached by default', {
         # clear the global environment
         rm(list=ls(envir = .TargetEnv), envir = .TargetEnv)
 
-        test_data <- data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40))
+        test_data <- tibble::as_tibble(data.frame(Names=c("a", "b", "c"), Ages=c(20,30,40)))
 
         # save test data as a csv in the data directory
         write.csv(test_data, file="data/test.csv", row.names = FALSE)
@@ -158,7 +158,7 @@ test_that('ignored data files are not loaded', {
   .save.config(config)
 
   # create some test data so the file can be loaded if not ignored
-  test_data <- data.frame(Names = c("a", "b", "c"), Ages = c(20,30,40))
+  test_data <- tibble::as_tibble(data.frame(Names = c("a", "b", "c"), Ages = c(20,30,40)))
 
   # write test data to files
   write.csv(test_data, file = 'data/test.csv', row.names = FALSE)


### PR DESCRIPTION
As per feature request #215, this PR implements a change to convert all loaded data to `tibble`s. The change is mostly cosmetically as it stands, since it uses a different `print` function from a standard `data.frame`.
For now it doesn't use the full powers of the `tidyverse`, as it simply converts to a `tibble` instead of using the `readr` functions for loading data. The main rationale is that doing so would introduce a major backwards incompatibility as it removes the option `stringsAsFactors` altogether. Given the popularity of the `tidyverse` within the R community, and of course the performance improvements of the `readr` functions over the `base` functions, it is definitely something we as a project should consider. That would be for a version 1.x though I guess.